### PR TITLE
docs: expand README with project structure and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 ## Objetivo
 Este microfrontend é responsável por gerenciar entrevistas interativas, incluindo gravação de áudio e exibição de perguntas e respostas.
 
+## Estrutura do Projeto
+```
+├── src
+│   ├── components/      # Componentes React reutilizáveis (configurações, entrevistas, dashboard etc.)
+│   ├── hooks/           # Hooks customizados
+│   ├── lib/             # Funções utilitárias e serviços de API
+│   ├── pages/           # Rotas do Next.js (dashboard, home, interview, invite...)
+│   ├── styles/          # Estilos globais e temas
+│   ├── types/           # Definições de tipos e declarações
+│   └── utils/           # Utilitários gerais
+├── next.config.js       # Configuração do Next.js e Module Federation
+├── tailwind.config.ts   # Configuração do Tailwind CSS
+├── postcss.config.mjs   # Ajustes do PostCSS
+└── tsconfig.json        # Configuração do TypeScript
+```
+
 ## Instalação de Dependências
 1. Certifique-se de ter o Node.js instalado.
 2. Execute o comando:
@@ -34,3 +50,44 @@ npm run build
 2. Configure o `NEXT_PUBLIC_SHELL_REMOTE_URL` com a URL do shell principal.
 3. Importe e utilize o microfrontend conforme necessário.
 
+## Exemplos de Código e Uso
+
+### Hook de filtros de entrevista
+```tsx
+import { useInterviewFilters } from '@/hooks/useInterviewFilters';
+
+export function ListaEntrevistas() {
+  const { filters, handleFilterChange, resetFilters } = useInterviewFilters();
+
+  return (
+    <div>
+      <input
+        value={filters.status || ''}
+        onChange={(e) => handleFilterChange('status', e.target.value)}
+      />
+      <button onClick={resetFilters}>Limpar filtros</button>
+    </div>
+  );
+}
+```
+
+### Iniciando uma sessão de entrevista via API
+```ts
+import { createSession } from '@/lib/api';
+
+async function iniciarSessao(invitationId: string) {
+  const session = await createSession(invitationId, new Date().toISOString());
+  console.log('Sessão criada:', session.id);
+}
+```
+
+### Consumindo o microfrontend no shell
+```tsx
+import dynamic from 'next/dynamic';
+
+const InterviewApp = dynamic(() => import('mfe-entrevista/App'), { ssr: false });
+
+export default function ShellPage() {
+  return <InterviewApp />;
+}
+```


### PR DESCRIPTION
## Summary
- map repository layout and document key directories and config files
- outline installation, env variables, development, and build instructions
- add sample hook, API call, and module-federation snippets for developers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b1f178c08333b46389bf9c16b1e4